### PR TITLE
feat: add env VITE_FETCH_LINK_PREVIEW to control preview fetching

### DIFF
--- a/.vitepress/typescript/node/linkPreviewPlugin.ts
+++ b/.vitepress/typescript/node/linkPreviewPlugin.ts
@@ -79,6 +79,10 @@ export default function linkPreviewPlugin(md: MarkdownIt): void {
 }
 
 export async function createPreviewLinkOGDataJsonFile(): Promise<void> {
+  if (process.env.VITE_FETCH_LINK_PREVIEW !== 'true') {
+    console.log('⏭️ Skipping link preview fetching (VITE_FETCH_LINK_PREVIEW is not true)')
+    return
+  }
   const previewDir = path.resolve(process.cwd(), 'public/json/preview/')
   await fs.promises.mkdir(previewDir, { recursive: true })
 


### PR DESCRIPTION
This PR adds an environment variable `VITE_FETCH_LINK_PREVIEW` to control whether to fetch link previews during the build process. It defaults to false.

