### PR TITLE
fix(images): prevent CLS by injecting image dimensions

### DIFF
--- a/.vitepress/AGENTS.md
+++ b/.vitepress/AGENTS.md
@@ -7,6 +7,7 @@
 ## 架構
 
 - `.vitepress/config.ts` 是主要 VitePress 設定。它串接 Mermaid、本地搜尋、編輯連結、自動產生側邊欄、rewrites、Open Graph metadata、schema 注入與 link preview 快取產生。
+- `.vitepress/image-dimensions.json` 儲存遠端圖片的尺寸資料，用於優化 CLS。此檔案應被 commit 到儲存庫中。
 - `.vitepress/typescript/node/generateSidebar.ts` 會從 `docs/` 下的 Markdown 路徑建立側邊欄。
 - `.vitepress/typescript/node/generateRewrites.ts` 會把 `docs/` 原始路徑映射到公開 clean path，並移除公開 URL 中的底線。
 - `.vitepress/typescript/node/linkPreviewPlugin.ts` 處理外部連結的 preview 資料。

--- a/.vitepress/image-dimensions.json
+++ b/.vitepress/image-dimensions.json
@@ -1,0 +1,6 @@
+{
+  "https://upload.wikimedia.org/wikipedia/commons/f/fb/Okuhida_Onsengo_Hirayu%2C_Takayama%2C_Gifu_Prefecture_506-1433%2C_Japan_-_panoramio_%281%29.jpg": {
+    "width": 4000,
+    "height": 3000
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 - 使用 `npm run build` 驗證網站建置。
 - 使用 `npm run check` 檢查格式；使用 `npm run format` 套用格式化。
 - 大量修改中文內容時，使用 `npm run correct` 修正中英文間距等文字問題。
+- **圖片尺寸處理**：執行 `npm run gen:img` 掃描 Markdown 並更新 `.vitepress/image-dimensions.json` 尺寸快取。
 - 連結與圖片驗證腳本會發出網路請求。僅在需要時執行，並預期可能出現暫時性失敗：
   - `npx tsx scripts/verify-links.ts [path-or-url]`
   - `npx tsx scripts/verify-images.ts [path]`
@@ -20,14 +21,18 @@
 - 除了引用專有名詞、官方名稱、地址或來源標題外，內容應使用繁體中文（`zh-Hant-TW`）。
 - 優先做小而明確的事實型更新。旅遊資訊常變動，修改價格、營業時間、入境規則、票券、交通時刻或簽證資訊前，必須先確認最新官方來源。
 - 外部旅遊參考資料應使用官方來源：景點官網、政府機關、交通營運單位、觀光局、地方觀光協會，或 JNTO 等國家級旅遊機構。避免以個人部落格、評論平台、社群貼文或非官方商業整理文章作為引用。
-- 不要為內容頁加入本地二進位圖片檔。請使用外部託管圖片網址，合適時優先使用穩定的 Wikimedia Commons 網址。
-- 不要提交 `.vitepress/dist`、`public/json/preview`、快取或本地環境檔等產出物。
+- **圖片與 CLS 處理**：
+  - 不要為內容頁加入本地二進位圖片檔。請使用外部託管圖片網址，合適時優先使用穩定的 Wikimedia Commons 網址。
+  - **重要**：為了減少 Cumulative Layout Shift (CLS)，優先將 Markdown 圖片語法轉為 HTML `<img>` 標籤，並標註 `width`、`height` 與 `aspect-ratio`。
+  - 使用 `scripts/update-markdown-images.ts` 批次轉換已記錄尺寸的圖片。
+- 不要提交 `.vitepress/dist`、`public/json/preview`、快取（除了 `image-dimensions.json`）或本地環境檔等產出物。
 - 尊重現有檔名與網址形狀。移動或重新命名 Markdown 檔會改變公開網址與側邊欄連結；若需要保留舊路徑，請在 `scripts/create-moved-redirects.ts` 加入轉址。
 - 檔案與資料夾可使用非 ASCII 名稱。保留現有繁體中文命名風格，不要為了 ASCII 化而改寫路徑。
 - 除非使用者明確要求，不要執行 stage、commit、push 或其他 Git 歷史操作。
 
 ## Markdown 與連結
 
+- **路徑與編碼**：專案大量使用繁體中文資料夾與檔名。在處理檔案讀寫或正規表達式時，需注意 JavaScript 的 `decodeURIComponent` 與 `encodeURIComponent` 處理，以確保與 Markdown 內容中的網址一致。
 - VitePress 已啟用 clean URLs。內部 Markdown 連結通常省略 `.md`，例如 `./景點/東京晴空塔`。
 - `docs/` 內頁面請使用相對連結。
 - Markdown 連結與 schema URL 應保持非英文路徑可讀。不要對中文或日文路徑字元做百分比編碼；必要時可保留空格等標準符號編碼。

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 這個網站的目的是為了提供一個集中、易於更新的旅遊資訊平台。
 
-![Untitled](https://github.com/user-attachments/assets/c0d2f761-819b-43df-8e7e-b45db22f268a)
+<img src="https://github.com/user-attachments/assets/c0d2f761-819b-43df-8e7e-b45db22f268a" alt="Untitled" width="688" height="688" style="aspect-ratio: 688 / 688;">
 
 ## 網站特色
 

--- a/docs/台灣/台中/景點/台中國家歌劇院.md
+++ b/docs/台灣/台中/景點/台中國家歌劇院.md
@@ -4,7 +4,7 @@ title: 台中國家歌劇院
 
 # 台中國家歌劇院
 
-![台中國家歌劇院](https://upload.wikimedia.org/wikipedia/commons/b/bf/National_Taichung_Theater_2019.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/b/bf/National_Taichung_Theater_2019.jpg" alt="台中國家歌劇院" width="6000" height="4000" style="aspect-ratio: 6000 / 4000;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/台中/景點/彩虹眷村.md
+++ b/docs/台灣/台中/景點/彩虹眷村.md
@@ -4,7 +4,7 @@ title: 彩虹眷村
 
 # 彩虹眷村
 
-![彩虹眷村](https://upload.wikimedia.org/wikipedia/commons/c/c1/%E5%BD%A9%E8%99%B9%E7%9C%B7%E6%9D%91_%2810927199416%29.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/c/c1/%E5%BD%A9%E8%99%B9%E7%9C%B7%E6%9D%91_%2810927199416%29.jpg" alt="彩虹眷村" width="3072" height="4608" style="aspect-ratio: 3072 / 4608;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/台中/景點/高美濕地.md
+++ b/docs/台灣/台中/景點/高美濕地.md
@@ -4,7 +4,7 @@ title: 高美濕地
 
 # 高美濕地
 
-![高美濕地](https://upload.wikimedia.org/wikipedia/commons/1/1c/Gaomei_Wetland%2C_Taichung%2C_Taiwan_%28555594035%29_3.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/1/1c/Gaomei_Wetland%2C_Taichung%2C_Taiwan_%28555594035%29_3.jpg" alt="高美濕地" width="4000" height="2667" style="aspect-ratio: 4000 / 2667;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/台北/景點/中正紀念堂.md
+++ b/docs/台灣/台北/景點/中正紀念堂.md
@@ -4,7 +4,7 @@ title: 中正紀念堂
 
 # 中正紀念堂
 
-![中正紀念堂](https://upload.wikimedia.org/wikipedia/commons/d/d2/Chiang_Kai-shek_memorial_amk.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/d/d2/Chiang_Kai-shek_memorial_amk.jpg" alt="中正紀念堂" width="2900" height="1933" style="aspect-ratio: 2900 / 1933;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/台北/景點/台北101.md
+++ b/docs/台灣/台北/景點/台北101.md
@@ -4,7 +4,7 @@ title: 台北 101
 
 # 台北 101
 
-![台北 101](https://upload.wikimedia.org/wikipedia/commons/5/53/Taipei_101_2009_amk.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/5/53/Taipei_101_2009_amk.jpg" alt="台北 101" width="2000" height="3187" style="aspect-ratio: 2000 / 3187;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/台北/景點/國立故宮博物院.md
+++ b/docs/台灣/台北/景點/國立故宮博物院.md
@@ -4,7 +4,7 @@ title: 國立故宮博物院
 
 # 國立故宮博物院
 
-![國立故宮博物院](https://upload.wikimedia.org/wikipedia/commons/3/3e/National_Palace_Museum_%280155%29.JPG)
+<img src="https://upload.wikimedia.org/wikipedia/commons/3/3e/National_Palace_Museum_%280155%29.JPG" alt="國立故宮博物院" width="3072" height="2304" style="aspect-ratio: 3072 / 2304;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/台南/景點/奇美博物館.md
+++ b/docs/台灣/台南/景點/奇美博物館.md
@@ -4,7 +4,7 @@ title: 奇美博物館
 
 # 奇美博物館
 
-![奇美博物館](https://upload.wikimedia.org/wikipedia/commons/b/b1/%E5%A5%87%E7%BE%8E%E5%8D%9A%E7%89%A9%E9%A4%A8.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/b/b1/%E5%A5%87%E7%BE%8E%E5%8D%9A%E7%89%A9%E9%A4%A8.jpg" alt="奇美博物館" width="774" height="774" style="aspect-ratio: 774 / 774;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/台南/景點/安平古堡.md
+++ b/docs/台灣/台南/景點/安平古堡.md
@@ -4,7 +4,7 @@ title: 安平古堡
 
 # 安平古堡
 
-![安平古堡](https://upload.wikimedia.org/wikipedia/commons/a/a8/Anping_Fort.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/a/a8/Anping_Fort.jpg" alt="安平古堡" width="1996" height="1468" style="aspect-ratio: 1996 / 1468;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/台南/景點/神農街.md
+++ b/docs/台灣/台南/景點/神農街.md
@@ -4,7 +4,7 @@ title: 神農街
 
 # 神農街
 
-![神農街](https://upload.wikimedia.org/wikipedia/commons/d/d4/%E8%87%BA%E5%8D%97%E5%8C%97%E5%8B%A2%E8%A1%97.JPG)
+<img src="https://upload.wikimedia.org/wikipedia/commons/d/d4/%E8%87%BA%E5%8D%97%E5%8C%97%E5%8B%A2%E8%A1%97.JPG" alt="神農街" width="1600" height="1200" style="aspect-ratio: 1600 / 1200;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/台南/景點/赤崁樓.md
+++ b/docs/台灣/台南/景點/赤崁樓.md
@@ -4,7 +4,7 @@ title: 赤崁樓
 
 # 赤崁樓
 
-![赤崁樓](https://upload.wikimedia.org/wikipedia/commons/0/09/Tainan_Taiwan_Fort-Provintia-01.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/0/09/Tainan_Taiwan_Fort-Provintia-01.jpg" alt="赤崁樓" width="5032" height="3355" style="aspect-ratio: 5032 / 3355;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/台東/景點/小野柳.md
+++ b/docs/台灣/台東/景點/小野柳.md
@@ -4,7 +4,7 @@ title: 小野柳
 
 # 小野柳 (富岡地質公園)
 
-![小野柳](https://upload.wikimedia.org/wikipedia/commons/d/df/%E5%B0%8F%E9%87%8E%E6%9F%B3.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/d/df/%E5%B0%8F%E9%87%8E%E6%9F%B3.jpg" alt="小野柳" width="960" height="540" style="aspect-ratio: 960 / 540;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/宜蘭/景點/羅東夜市.md
+++ b/docs/台灣/宜蘭/景點/羅東夜市.md
@@ -4,7 +4,7 @@ title: 羅東夜市
 
 # 羅東夜市
 
-![羅東夜市](https://upload.wikimedia.org/wikipedia/commons/6/69/%E7%BE%85%E6%9D%B1%E5%A4%9C%E5%B8%82_-_panoramio.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/6/69/%E7%BE%85%E6%9D%B1%E5%A4%9C%E5%B8%82_-_panoramio.jpg" alt="羅東夜市" width="2816" height="2112" style="aspect-ratio: 2816 / 2112;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/宜蘭/景點/蘭陽博物館.md
+++ b/docs/台灣/宜蘭/景點/蘭陽博物館.md
@@ -4,7 +4,7 @@ title: 蘭陽博物館
 
 # 蘭陽博物館
 
-![蘭陽博物館](https://upload.wikimedia.org/wikipedia/commons/d/d0/%E8%98%AD%E9%99%BD%E5%8D%9A%E7%89%A9%E9%A4%A8.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/d/d0/%E8%98%AD%E9%99%BD%E5%8D%9A%E7%89%A9%E9%A4%A8.jpg" alt="蘭陽博物館" width="1764" height="1323" style="aspect-ratio: 1764 / 1323;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/屏東/景點/國立海洋生物博物館.md
+++ b/docs/台灣/屏東/景點/國立海洋生物博物館.md
@@ -4,7 +4,7 @@ title: 國立海洋生物博物館
 
 # 國立海洋生物博物館
 
-![國立海洋生物博物館](https://upload.wikimedia.org/wikipedia/commons/5/51/NMMBA_II.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/5/51/NMMBA_II.jpg" alt="國立海洋生物博物館" width="1400" height="787" style="aspect-ratio: 1400 / 787;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/新竹/景點/新竹都城隍廟.md
+++ b/docs/台灣/新竹/景點/新竹都城隍廟.md
@@ -4,7 +4,7 @@ title: 新竹都城隍廟
 
 # 新竹都城隍廟
 
-![新竹都城隍廟](https://upload.wikimedia.org/wikipedia/commons/4/49/%E6%96%B0%E7%AB%B9%E9%83%BD%E5%9F%8E%E9%9A%8D%E5%BB%9F.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/4/49/%E6%96%B0%E7%AB%B9%E9%83%BD%E5%9F%8E%E9%9A%8D%E5%BB%9F.jpg" alt="新竹都城隍廟" width="5116" height="3842" style="aspect-ratio: 5116 / 3842;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/桃園/景點/大溪老街.md
+++ b/docs/台灣/桃園/景點/大溪老街.md
@@ -4,7 +4,7 @@ title: 大溪老街
 
 # 大溪老街
 
-![大溪老街 巴洛克建築](https://upload.wikimedia.org/wikipedia/commons/5/55/Daxi_Old_Street.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/5/55/Daxi_Old_Street.jpg" alt="大溪老街 巴洛克建築" width="1024" height="768" style="aspect-ratio: 1024 / 768;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/桃園/景點/慈湖陵寢.md
+++ b/docs/台灣/桃園/景點/慈湖陵寢.md
@@ -4,7 +4,7 @@ title: 慈湖陵寢
 
 # 慈湖陵寢
 
-![慈湖陵寢 外部景觀](https://upload.wikimedia.org/wikipedia/commons/8/81/Cihu_Mausoleum.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/8/81/Cihu_Mausoleum.jpg" alt="慈湖陵寢 外部景觀" width="4032" height="3024" style="aspect-ratio: 4032 / 3024;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/花蓮/景點/太魯閣國家公園.md
+++ b/docs/台灣/花蓮/景點/太魯閣國家公園.md
@@ -4,7 +4,7 @@ title: 太魯閣國家公園
 
 # 太魯閣國家公園
 
-![太魯閣峽谷 絕景](https://upload.wikimedia.org/wikipedia/commons/f/f2/Taroko_National_Park.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/f/f2/Taroko_National_Park.jpg" alt="太魯閣峽谷 絕景" width="3468" height="4624" style="aspect-ratio: 3468 / 4624;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/花蓮/景點/東大門夜市.md
+++ b/docs/台灣/花蓮/景點/東大門夜市.md
@@ -4,7 +4,7 @@ title: 東大門夜市
 
 # 東大門夜市
 
-![東大門夜市 繁華景象](https://upload.wikimedia.org/wikipedia/commons/7/78/Hualien_Dongdamen_Night_Market.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/7/78/Hualien_Dongdamen_Night_Market.jpg" alt="東大門夜市 繁華景象" width="2046" height="1459" style="aspect-ratio: 2046 / 1459;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/高雄/景點/蓮池潭.md
+++ b/docs/台灣/高雄/景點/蓮池潭.md
@@ -4,7 +4,7 @@ title: 蓮池潭
 
 # 蓮池潭
 
-![龍虎塔](https://upload.wikimedia.org/wikipedia/commons/9/90/Dragon_and_Tiger_Pagodas_02.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/9/90/Dragon_and_Tiger_Pagodas_02.jpg" alt="龍虎塔" width="3038" height="1975" style="aspect-ratio: 3038 / 1975;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/台灣/高雄/景點/駁二藝術特區.md
+++ b/docs/台灣/高雄/景點/駁二藝術特區.md
@@ -4,7 +4,7 @@ title: 駁二藝術特區
 
 # 駁二藝術特區
 
-![駁二藝術特區](https://upload.wikimedia.org/wikipedia/commons/3/3f/The_Pier-2_Art_Center_2020070902.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/3/3f/The_Pier-2_Art_Center_2020070902.jpg" alt="駁二藝術特區" width="6000" height="4000" style="aspect-ratio: 6000 / 4000;">
 _圖片來源：Wikimedia Commons_
 
 ## 簡介

--- a/docs/日本/北海道/函館/景點/五稜郭公園.md
+++ b/docs/日本/北海道/函館/景點/五稜郭公園.md
@@ -2,10 +2,10 @@
 
 五稜郭是日本江戶時代末期由江戶幕府修築的一座星形要塞。它是日本第一座西式堡壘，也是「箱館戰爭」的最終戰場。現在則作為公園開放，是函館最著名的賞櫻勝地與歷史地標。
 
-![五稜郭](https://upload.wikimedia.org/wikipedia/commons/5/5a/Goryokaku-Tower-02.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/5/5a/Goryokaku-Tower-02.jpg" alt="五稜郭" width="1846" height="2776" style="aspect-ratio: 1846 / 2776;">
 _圖片來源：Wikimedia Commons_
 
-![五稜郭](https://upload.wikimedia.org/wikipedia/commons/f/f9/Goryokaku_Tower_Hakodate_Hokkaido_Japan10n.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/f/f9/Goryokaku_Tower_Hakodate_Hokkaido_Japan10n.jpg" alt="五稜郭" width="4912" height="3264" style="aspect-ratio: 4912 / 3264;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/北海道/函館/景點/元町教會群.md
+++ b/docs/日本/北海道/函館/景點/元町教會群.md
@@ -2,7 +2,7 @@
 
 函館元町地區位於函館山腳下，是函館開港初期外國人居留地的中心。這裡保留了許多充滿異國風情的坡道與歷史建築，其中最著名的便是風格各異的教會群。
 
-![元町教會群](https://upload.wikimedia.org/wikipedia/commons/d/d7/Motomachi_Catholic_Church_in_Hakodate_Hokkaido_Japan03n.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/d/d7/Motomachi_Catholic_Church_in_Hakodate_Hokkaido_Japan03n.jpg" alt="元町教會群" width="4912" height="3264" style="aspect-ratio: 4912 / 3264;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/北海道/函館/景點/函館山.md
+++ b/docs/日本/北海道/函館/景點/函館山.md
@@ -2,7 +2,7 @@
 
 函館山位於函館市西側，海拔 334 公尺。這裡的夜景被譽為「世界三大夜景」之一，是來到函館絕對不能錯過的景點。
 
-![函館夜景](https://files.catbox.moe/8k0o1d.png)
+<img src="https://files.catbox.moe/8k0o1d.png" alt="函館夜景" width="1024" height="1024" style="aspect-ratio: 1024 / 1024;">
 _圖片來源：AI 生成示意圖 (依據函館山實景生成)_
 
 ## 景點特色

--- a/docs/日本/北海道/函館/景點/函館朝市.md
+++ b/docs/日本/北海道/函館/景點/函館朝市.md
@@ -2,7 +2,7 @@
 
 函館朝市是日本最知名的朝市之一，擁有約 250 家店鋪。這裡以新鮮的海產聞名，遊客可以用實惠的價格吃到豐盛的海鮮丼、壽司，還能體驗有趣的「釣烏賊」。
 
-![函館朝市](https://upload.wikimedia.org/wikipedia/commons/a/ac/Hakodate_Morning_Market%2C_Hakodate_Asaichi%2C_Hakodate%2C_2014.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/a/ac/Hakodate_Morning_Market%2C_Hakodate_Asaichi%2C_Hakodate%2C_2014.jpg" alt="函館朝市" width="3264" height="2448" style="aspect-ratio: 3264 / 2448;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/北海道/函館/景點/大沼國定公園.md
+++ b/docs/日本/北海道/函館/景點/大沼國定公園.md
@@ -2,7 +2,7 @@
 
 大沼國定公園位於函館北郊，以其壯麗的駒之岳火山為背景，擁有大沼、小沼、蓴菜沼等美麗的湖泊，是北海道著名的自然風景區。
 
-![大沼國定公園](https://upload.wikimedia.org/wikipedia/commons/d/d8/Onuma_National_Park_-_panoramio.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/d/d8/Onuma_National_Park_-_panoramio.jpg" alt="大沼國定公園" width="1600" height="1200" style="aspect-ratio: 1600 / 1200;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/北海道/函館/景點/金森紅磚倉庫.md
+++ b/docs/日本/北海道/函館/景點/金森紅磚倉庫.md
@@ -2,7 +2,7 @@
 
 金森紅磚倉庫位於函館灣區域，是函館最具代表性的觀光景點之一。這些由紅磚砌成的倉庫群建於明治時期，見證了函館作為國際貿易港口的繁榮歷史。
 
-![金森紅磚倉庫](https://upload.wikimedia.org/wikipedia/commons/3/3b/Kanemori_Red_Brick_Warehouse_20140807.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/3/3b/Kanemori_Red_Brick_Warehouse_20140807.jpg" alt="金森紅磚倉庫" width="3872" height="2592" style="aspect-ratio: 3872 / 2592;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/北海道/小樽/景點/堺町通.md
+++ b/docs/日本/北海道/小樽/景點/堺町通.md
@@ -2,7 +2,7 @@
 
 堺町通是小樽市中心的一條歷史商業街，全長約 800 公尺。這裡曾是小樽最繁華的商圈，現在則聚集了許多由歷史建築改建而成的特色店鋪，是遊客逛街購物與享用甜點的首選之地。
 
-![堺町通](https://upload.wikimedia.org/wikipedia/commons/c/c5/Sakaimachi_street_Otaru_Hokkaido16n.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/c/c5/Sakaimachi_street_Otaru_Hokkaido16n.jpg" alt="堺町通" width="4740" height="3160" style="aspect-ratio: 4740 / 3160;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/北海道/小樽/景點/小樽運河.md
+++ b/docs/日本/北海道/小樽/景點/小樽運河.md
@@ -2,7 +2,7 @@
 
 小樽運河竣工於 1923 年，是北海道開拓時期的重要物流樞紐。雖然現在已失去運輸功能，但其獨特的石造倉庫群與充滿異國情調的氛圍，使其成為小樽最具代表性的地標。
 
-![小樽運河](https://upload.wikimedia.org/wikipedia/commons/a/a7/Otaru_Canal_20140817.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/a/a7/Otaru_Canal_20140817.jpg" alt="小樽運河" width="3872" height="2592" style="aspect-ratio: 3872 / 2592;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/北海道/小樽/景點/小樽音樂盒堂.md
+++ b/docs/日本/北海道/小樽/景點/小樽音樂盒堂.md
@@ -2,7 +2,7 @@
 
 小樽音樂盒堂是日本規模最大的音樂盒專賣店，其主館建築建於 1912 年，是一座充滿懷舊氛圍的紅磚造建築。
 
-![小樽音樂盒堂](https://upload.wikimedia.org/wikipedia/commons/2/29/Otaru_Music_Box_Museum_interior.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/2/29/Otaru_Music_Box_Museum_interior.jpg" alt="小樽音樂盒堂" width="3264" height="2448" style="aspect-ratio: 3264 / 2448;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/北海道/旭川/景點/上野農場.md
+++ b/docs/日本/北海道/旭川/景點/上野農場.md
@@ -2,7 +2,7 @@
 
 上野農場是由著名景觀設計師上野砂由紀 (Sayuyuki Ueno) 所設計的「北海道花園」。這裡將傳統的英式花園風格與北海道的氣候與土壤相結合，創造出獨特的「北海道風花園」。
 
-![上野農場](https://upload.wikimedia.org/wikipedia/commons/c/ce/Ueno_Farm_%2819310228258%29.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/c/ce/Ueno_Farm_%2819310228258%29.jpg" alt="上野農場" width="3008" height="2000" style="aspect-ratio: 3008 / 2000;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/北海道/札幌/景點/札幌鐘樓.md
+++ b/docs/日本/北海道/札幌/景點/札幌鐘樓.md
@@ -2,7 +2,7 @@
 
 札幌市鐘樓是札幌的地標性建築，也是日本現存最古老的鐘樓。它建於 1878 年，最初是札幌農學校（現北海道大學）的演武場。
 
-![札幌鐘樓](https://upload.wikimedia.org/wikipedia/commons/6/6b/Sapporo_Clock_Tower_Hokkaido_Japan.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/6/6b/Sapporo_Clock_Tower_Hokkaido_Japan.jpg" alt="札幌鐘樓" width="400" height="602" style="aspect-ratio: 400 / 602;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/北海道/札幌/景點/薄野.md
+++ b/docs/日本/北海道/札幌/景點/薄野.md
@@ -2,10 +2,10 @@
 
 薄野是札幌最大的娛樂區，也是日本三大紅燈區之一（與東京歌舞伎町、福岡中洲並列）。這裡聚集了數千家餐廳、酒吧、卡拉 OK 與夜總會，是札幌夜生活的核心。
 
-![薄野](https://upload.wikimedia.org/wikipedia/commons/3/34/Spectaculars_of_Susukino-Sapporo.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/3/34/Spectaculars_of_Susukino-Sapporo.jpg" alt="薄野" width="2870" height="2155" style="aspect-ratio: 2870 / 2155;">
 _圖片來源：Wikimedia Commons_
 
-![薄野](https://upload.wikimedia.org/wikipedia/commons/1/1e/Susukino_by_flimdy_in_Sapporo.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/1/1e/Susukino_by_flimdy_in_Sapporo.jpg" alt="薄野" width="681" height="1024" style="aspect-ratio: 681 / 1024;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/北海道/洞爺湖/景點/有珠山纜車.md
+++ b/docs/日本/北海道/洞爺湖/景點/有珠山纜車.md
@@ -2,7 +2,7 @@
 
 有珠山是一座至今仍活動頻繁的活火山，最近一次噴發是在 2000 年。搭乘有珠山纜車，只需 6 分鐘即可抵達山頂，近距離觀察火山地貌並俯瞰洞爺湖全景。
 
-![有珠山](https://upload.wikimedia.org/wikipedia/commons/b/b2/The_View_from_Usuzan_Ropeway.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/b/b2/The_View_from_Usuzan_Ropeway.jpg" alt="有珠山" width="1280" height="960" style="aspect-ratio: 1280 / 960;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/北海道/登別/景點/地獄谷.md
+++ b/docs/日本/北海道/登別/景點/地獄谷.md
@@ -2,7 +2,7 @@
 
 登別地獄谷是約一萬年前笠山爆發形成的火山口遺跡。這裡是登別溫泉的主要源頭，每天湧出量高達一萬噸，供應給溫泉街的各大旅館。
 
-![登別地獄谷](https://upload.wikimedia.org/wikipedia/commons/c/c2/1_Jigokudani_hell_valley_2015.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/c/c2/1_Jigokudani_hell_valley_2015.jpg" alt="登別地獄谷" width="15681" height="5772" style="aspect-ratio: 15681 / 5772;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/北海道/登別/景點/大湯沼.md
+++ b/docs/日本/北海道/登別/景點/大湯沼.md
@@ -2,7 +2,7 @@
 
 大湯沼是日和山火山口噴發後形成的葫蘆形火山口湖，周長約 1 公里。湖底噴出約 130 度的硫磺泉，使湖面始終籠罩在熱氣之中。
 
-![大湯沼](https://upload.wikimedia.org/wikipedia/commons/5/5f/Oyunuma_Pond%2C_Noboribetsu_Onsen%2C_Hokkaido%2C_April_2023_08.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/5/5f/Oyunuma_Pond%2C_Noboribetsu_Onsen%2C_Hokkaido%2C_April_2023_08.jpg" alt="大湯沼" width="4608" height="3456" style="aspect-ratio: 4608 / 3456;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/北海道/知床/景點/知床五湖.md
+++ b/docs/日本/北海道/知床/景點/知床五湖.md
@@ -2,7 +2,7 @@
 
 知床五湖是位於知床半島原始森林中的五個神祕湖泊，被譽為「知床的寶石」。這裡不僅可以欣賞到湖泊倒映知床連峰的美景，也是近距離接觸世界自然遺產生態的最佳地點。
 
-![知床五湖](https://upload.wikimedia.org/wikipedia/commons/f/f1/Shiretoko_Five_Lakes_20140811-1.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/f/f1/Shiretoko_Five_Lakes_20140811-1.jpg" alt="知床五湖" width="3872" height="2592" style="aspect-ratio: 3872 / 2592;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/北海道/美瑛/景點/白金青池.md
+++ b/docs/日本/北海道/美瑛/景點/白金青池.md
@@ -2,7 +2,7 @@
 
 白金青池位於美瑛町白金地區，是為了防止十勝岳火山噴發後的泥流災害而修築的人工堤防。因其池水呈現不可思議的鈷藍色，搭配池中枯死的落葉松，營造出極其夢幻且神祕的氛圍，因而成為全球知名的景點。
 
-![白金青池](https://upload.wikimedia.org/wikipedia/commons/f/ff/Shirogane_Blue_Pond_2015-09-15.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/f/ff/Shirogane_Blue_Pond_2015-09-15.jpg" alt="白金青池" width="3264" height="2448" style="aspect-ratio: 3264 / 2448;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/北海道/美瑛/景點/白髭瀑布.md
+++ b/docs/日本/北海道/美瑛/景點/白髭瀑布.md
@@ -2,7 +2,7 @@
 
 白髭瀑布位於白金溫泉區，是美瑛川源頭的一部分。瀑布從岩石縫隙中湧出，呈現出無數條細長的白色水流，宛如老人的白鬍鬚，因而得名。
 
-![白髭瀑布](https://upload.wikimedia.org/wikipedia/commons/e/e1/Shirahige_Falls%2C_Biei_River%2C_Hokkaido%2C_Japan.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/e/e1/Shirahige_Falls%2C_Biei_River%2C_Hokkaido%2C_Japan.jpg" alt="白髭瀑布" width="6000" height="4000" style="aspect-ratio: 6000 / 4000;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/富山/景點/五箇山.md
+++ b/docs/日本/富山/景點/五箇山.md
@@ -1,6 +1,6 @@
 # 五箇山合掌集落
 
-![五箇山](https://upload.wikimedia.org/wikipedia/commons/1/1d/Gokayama_suganuma.JPG)
+<img src="https://upload.wikimedia.org/wikipedia/commons/1/1d/Gokayama_suganuma.JPG" alt="五箇山" width="1200" height="1600" style="aspect-ratio: 1200 / 1600;">
 _圖片來源：Wikimedia Commons_
 
 五箇山位於富山縣西南端，與岐阜縣的**[白川鄉](../../岐阜/景點/白川鄉)**一同於 1995 年登錄為世界文化遺產。

--- a/docs/日本/山形/景點/銀山溫泉.md
+++ b/docs/日本/山形/景點/銀山溫泉.md
@@ -6,8 +6,8 @@
 
 ## 散步路線
 
-![image](https://github.com/user-attachments/assets/8a7fadfa-c9c6-4da1-b7d9-a5a7b0ed462e)
-![image](https://github.com/user-attachments/assets/96d2f542-ad68-41c6-85d2-d130748d8303)
+<img src="https://github.com/user-attachments/assets/8a7fadfa-c9c6-4da1-b7d9-a5a7b0ed462e" alt="image" width="1000" height="380" style="aspect-ratio: 1000 / 380;">
+<img src="https://github.com/user-attachments/assets/96d2f542-ad68-41c6-85d2-d130748d8303" alt="image" width="477" height="760" style="aspect-ratio: 477 / 760;">
 _圖片來源：銀山溫泉官網_
 
 資料來源及更多資訊：[銀山温泉 公式サイト | 歴史と温泉 - 散策](https://www.ginzanonsen.jp/ginzan/walk.html)

--- a/docs/日本/山梨/_交通/河口湖周遊巴士.md
+++ b/docs/日本/山梨/_交通/河口湖周遊巴士.md
@@ -1,6 +1,6 @@
 # 河口湖周遊巴士 (紅線 / Red Line)
 
-![image](https://github.com/user-attachments/assets/e09b7ed4-2e04-4b96-827f-51dfc22e42ad)
+<img src="https://github.com/user-attachments/assets/e09b7ed4-2e04-4b96-827f-51dfc22e42ad" alt="image" width="240" height="179" style="aspect-ratio: 240 / 179;">
 
 <!-- 圖片來自富士急官方網站 https://bus.fujikyu.co.jp/rosen/shuyuomuni -->
 

--- a/docs/日本/山梨/_交通/鐵路交通.md
+++ b/docs/日本/山梨/_交通/鐵路交通.md
@@ -1,6 +1,6 @@
 # 鐵路交通：富士回遊 & 富士急行線
 
-![JR 特急富士回遊號](https://upload.wikimedia.org/wikipedia/commons/8/8f/Fujikaiyu_e353.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/8/8f/Fujikaiyu_e353.jpg" alt="JR 特急富士回遊號" width="5431" height="3621" style="aspect-ratio: 5431 / 3621;">
 
 <!-- 圖片來源：Wikimedia Commons -->
 

--- a/docs/日本/山梨/景點/久保田一竹美術館.md
+++ b/docs/日本/山梨/景點/久保田一竹美術館.md
@@ -1,6 +1,6 @@
 # 久保田一竹美術館 (Itchiku Kubota Art Museum)
 
-![久保田一竹美術館建築](https://upload.wikimedia.org/wikipedia/commons/a/a5/Itchiku_Kubota_Art_Museum_2018a.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/a/a5/Itchiku_Kubota_Art_Museum_2018a.jpg" alt="久保田一竹美術館建築" width="4401" height="2839" style="aspect-ratio: 4401 / 2839;">
 
 <!-- 圖片來源：Wikimedia Commons -->
 

--- a/docs/日本/山梨/景點/大石公園.md
+++ b/docs/日本/山梨/景點/大石公園.md
@@ -1,6 +1,6 @@
 # 大石公園 (Oishi Park)
 
-![大石公園與富士山](https://upload.wikimedia.org/wikipedia/commons/0/04/Mount_Fuji_from_Oishi_Park.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/0/04/Mount_Fuji_from_Oishi_Park.jpg" alt="大石公園與富士山" width="5184" height="3456" style="aspect-ratio: 5184 / 3456;">
 
 <!-- 圖片來源：Wikimedia Commons -->
 

--- a/docs/日本/山梨/景點/富岳風穴.md
+++ b/docs/日本/山梨/景點/富岳風穴.md
@@ -1,6 +1,6 @@
 # 富岳風穴 (Fugaku Wind Cave)
 
-![富岳風穴入口](https://upload.wikimedia.org/wikipedia/commons/9/92/Fugaku_Fuketu_Entrance_20161025.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/9/92/Fugaku_Fuketu_Entrance_20161025.jpg" alt="富岳風穴入口" width="3264" height="1836" style="aspect-ratio: 3264 / 1836;">
 
 <!-- 圖片來源：Wikimedia Commons -->
 

--- a/docs/日本/山梨/景點/山梨寶石博物館.md
+++ b/docs/日本/山梨/景點/山梨寶石博物館.md
@@ -1,6 +1,6 @@
 # 山梨寶石博物館 (Yamanashi Gem Museum)
 
-![山梨寶石博物館外觀](https://upload.wikimedia.org/wikipedia/commons/3/31/Yamanashi_Gem_Museum.JPG)
+<img src="https://upload.wikimedia.org/wikipedia/commons/3/31/Yamanashi_Gem_Museum.JPG" alt="山梨寶石博物館外觀" width="2048" height="1536" style="aspect-ratio: 2048 / 1536;">
 
 <!-- 圖片來源：Wikimedia Commons -->
 

--- a/docs/日本/山梨/景點/本栖湖.md
+++ b/docs/日本/山梨/景點/本栖湖.md
@@ -1,6 +1,6 @@
 # 本栖湖 (Lake Motosu)
 
-![本栖湖與富士山](https://upload.wikimedia.org/wikipedia/commons/c/c9/Mount_Fuji_from_Lake_Motosu.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/c/c9/Mount_Fuji_from_Lake_Motosu.jpg" alt="本栖湖與富士山" width="5184" height="3456" style="aspect-ratio: 5184 / 3456;">
 
 <!-- 圖片來源：Wikimedia Commons -->
 

--- a/docs/日本/山梨/景點/河口湖紅葉迴廊.md
+++ b/docs/日本/山梨/景點/河口湖紅葉迴廊.md
@@ -1,6 +1,6 @@
 # 河口湖紅葉迴廊 (Momiji Corridor)
 
-![河口湖紅葉迴廊秋景](https://upload.wikimedia.org/wikipedia/commons/0/02/Maple_Corridor_%2816191466966%29.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/0/02/Maple_Corridor_%2816191466966%29.jpg" alt="河口湖紅葉迴廊秋景" width="4000" height="3000" style="aspect-ratio: 4000 / 3000;">
 
 <!-- 圖片來源：Wikimedia Commons -->
 

--- a/docs/日本/山梨/景點/河口湖音樂盒之森美術館.md
+++ b/docs/日本/山梨/景點/河口湖音樂盒之森美術館.md
@@ -1,6 +1,6 @@
 # 河口湖音樂盒之森美術館 (Kawaguchiko Music Forest Museum)
 
-![河口湖音樂盒之森美術館建築](https://upload.wikimedia.org/wikipedia/commons/5/5d/Kawaguchiko_Music_Forest_Museum_2018a.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/5/5d/Kawaguchiko_Music_Forest_Museum_2018a.jpg" alt="河口湖音樂盒之森美術館建築" width="4496" height="3000" style="aspect-ratio: 4496 / 3000;">
 
 <!-- 圖片來源：Wikimedia Commons -->
 

--- a/docs/日本/山梨/景點/精進湖.md
+++ b/docs/日本/山梨/景點/精進湖.md
@@ -1,6 +1,6 @@
 # 精進湖 (Lake Shoji)
 
-![精進湖與富士山倒影](https://upload.wikimedia.org/wikipedia/commons/5/51/Mount_Fuji_from_Lake_Sh%C5%8Dji.JPG)
+<img src="https://upload.wikimedia.org/wikipedia/commons/5/51/Mount_Fuji_from_Lake_Sh%C5%8Dji.JPG" alt="精進湖與富士山倒影" width="5184" height="3456" style="aspect-ratio: 5184 / 3456;">
 
 <!-- 圖片來源：Wikimedia Commons -->
 

--- a/docs/日本/山梨/景點/西湖療癒之里根場.md
+++ b/docs/日本/山梨/景點/西湖療癒之里根場.md
@@ -1,6 +1,6 @@
 # 西湖療癒之里根場 (Saiko Iyashi no Sato Nenba)
 
-![西湖療癒之里根場的合掌造村落](https://upload.wikimedia.org/wikipedia/commons/c/ca/Saiko-iyashinosato-nenba2.JPG)
+<img src="https://upload.wikimedia.org/wikipedia/commons/c/ca/Saiko-iyashinosato-nenba2.JPG" alt="西湖療癒之里根場的合掌造村落" width="3648" height="2736" style="aspect-ratio: 3648 / 2736;">
 
 <!-- 圖片來源：Wikimedia Commons -->
 

--- a/docs/日本/山梨/景點/西湖蝙蝠穴.md
+++ b/docs/日本/山梨/景點/西湖蝙蝠穴.md
@@ -1,6 +1,6 @@
 # 西湖蝙蝠穴 (Saiko Bat Cave)
 
-![西湖蝙蝠穴入口](https://upload.wikimedia.org/wikipedia/commons/d/dc/Lake_Saiko_Bat_Cave_Entrance.JPG)
+<img src="https://upload.wikimedia.org/wikipedia/commons/d/dc/Lake_Saiko_Bat_Cave_Entrance.JPG" alt="西湖蝙蝠穴入口" width="4000" height="3000" style="aspect-ratio: 4000 / 3000;">
 
 <!-- 圖片來源：Wikimedia Commons -->
 

--- a/docs/日本/山梨/景點/鳴澤冰穴.md
+++ b/docs/日本/山梨/景點/鳴澤冰穴.md
@@ -1,6 +1,6 @@
 # 鳴澤冰穴 (Narusawa Ice Cave)
 
-![鳴澤冰穴入口](https://upload.wikimedia.org/wikipedia/commons/5/58/Narusawa_Hyoketsu_Entrance_20161025.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/5/58/Narusawa_Hyoketsu_Entrance_20161025.jpg" alt="鳴澤冰穴入口" width="3264" height="1836" style="aspect-ratio: 3264 / 1836;">
 
 <!-- 圖片來源：Wikimedia Commons -->
 

--- a/docs/日本/岐阜/景點/下呂溫泉.md
+++ b/docs/日本/岐阜/景點/下呂溫泉.md
@@ -1,6 +1,6 @@
 # 下呂溫泉
 
-![下呂溫泉](https://upload.wikimedia.org/wikipedia/commons/3/32/Gero-onsen01s3200.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/3/32/Gero-onsen01s3200.jpg" alt="下呂溫泉" width="3200" height="2133" style="aspect-ratio: 3200 / 2133;">
 _圖片來源：Wikimedia Commons_
 
 下呂溫泉與兵庫縣的有馬溫泉、群馬縣的草津溫泉並稱為「日本三大名泉」。自室町時代以來，這裡便以優質的泉質聞名，水質觸感滑順，具有「美人湯」的美譽。

--- a/docs/日本/岐阜/景點/奧飛驒溫泉鄉.md
+++ b/docs/日本/岐阜/景點/奧飛驒溫泉鄉.md
@@ -1,6 +1,6 @@
 # 奧飛驒溫泉鄉
 
-![奧飛驒溫泉鄉](https://upload.wikimedia.org/wikipedia/commons/f/fb/Okuhida_Onsengo_Hirayu%2C_Takayama%2C_Gifu_Prefecture_506-1433%2C_Japan_-_panoramio_%281%29.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/f/fb/Okuhida_Onsengo_Hirayu%2C_Takayama%2C_Gifu_Prefecture_506-1433%2C_Japan_-_panoramio_%281%29.jpg" alt="奧飛驒溫泉鄉" width="4000" height="3000" style="aspect-ratio: 4000 / 3000;">
 _圖片來源：Wikimedia Commons_
 
 奧飛驒溫泉鄉位於北阿爾卑斯山腳下，由平湯、福地、新平湯、栃尾及新穗高五個溫泉區組成。這裡擁有日本最密集的露天風呂，是感受大自然與溫泉完美結合的絕佳地點。

--- a/docs/日本/岐阜/景點/岐阜城.md
+++ b/docs/日本/岐阜/景點/岐阜城.md
@@ -1,6 +1,6 @@
 # 岐阜城
 
-![岐阜城](https://upload.wikimedia.org/wikipedia/commons/9/9d/Gifu_castle.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/9/9d/Gifu_castle.jpg" alt="岐阜城" width="4000" height="2250" style="aspect-ratio: 4000 / 2250;">
 _圖片來源：Wikimedia Commons_
 
 岐阜城矗立於海拔 329 公尺的金華山山頂，是岐阜市的象徵。這裡曾是戰國大名織田信長「天下布武」的根據地，在歷史上具有極其重要的地位。

--- a/docs/日本/岐阜/景點/白川鄉.md
+++ b/docs/日本/岐阜/景點/白川鄉.md
@@ -1,6 +1,6 @@
 # 白川鄉
 
-![白川鄉](https://upload.wikimedia.org/wikipedia/commons/6/63/Shirakawa-go_002.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/6/63/Shirakawa-go_002.jpg" alt="白川鄉" width="2048" height="1364" style="aspect-ratio: 2048 / 1364;">
 _圖片來源：Wikimedia Commons_
 
 白川鄉位於岐阜縣與富山縣交界處，於 1995 年被登錄為世界文化遺產。這裡最著名的便是其獨特的「合掌造」建築，陡峭的屋頂如同雙手合十，旨在防止厚重的積雪壓垮房舍。

--- a/docs/日本/岐阜/景點/馬籠宿.md
+++ b/docs/日本/岐阜/景點/馬籠宿.md
@@ -1,6 +1,6 @@
 # 馬籠宿
 
-![馬籠宿](https://upload.wikimedia.org/wikipedia/commons/f/f0/Magome-Juku_StoneSlope.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/f/f0/Magome-Juku_StoneSlope.jpg" alt="馬籠宿" width="1200" height="800" style="aspect-ratio: 1200 / 800;">
 _圖片來源：Wikimedia Commons_
 
 馬籠宿位於岐阜縣中津川市，是中山道 69 次中的第 43 號宿場。這裡與長野縣的**[妻籠宿](../../長野/景點/妻籠宿)**齊名，兩地之間的「妻籠－馬籠古道」是熱門的健行路線。

--- a/docs/日本/岐阜/景點/高山老街.md
+++ b/docs/日本/岐阜/景點/高山老街.md
@@ -1,6 +1,6 @@
 # 高山老街 (飛驒高山)
 
-![高山老街](https://upload.wikimedia.org/wikipedia/commons/d/d8/Sanmachi_Takayama03ds3200.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/d/d8/Sanmachi_Takayama03ds3200.jpg" alt="高山老街" width="3200" height="2142" style="aspect-ratio: 3200 / 2142;">
 _圖片來源：Wikimedia Commons_
 
 高山市位於岐阜縣北部，因其完整保存的江戶時代街道而被譽為「飛驒的小京都」。老街（三町傳統建造物群保存地區）是遊客感受古日本氣息、品嚐飛驒牛與當地清酒的首選之地。

--- a/docs/日本/石川/景點/兼六園.md
+++ b/docs/日本/石川/景點/兼六園.md
@@ -1,6 +1,6 @@
 # 兼六園
 
-![兼六園](https://upload.wikimedia.org/wikipedia/commons/e/e3/Kenrokuen_garden_1.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/e/e3/Kenrokuen_garden_1.jpg" alt="兼六園" width="2272" height="1704" style="aspect-ratio: 2272 / 1704;">
 _圖片來源：Wikimedia Commons_
 
 兼六園位於金澤市中心，是日本最具代表性的迴遊式大名庭園。它與茨城縣水戶市的「偕樂園」、岡山縣岡山市的「後樂園」並列為日本三大名園。

--- a/docs/日本/福井/景點/永平寺.md
+++ b/docs/日本/福井/景點/永平寺.md
@@ -1,6 +1,6 @@
 # 永平寺
 
-![永平寺](https://upload.wikimedia.org/wikipedia/commons/7/7c/Eiheiji.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/7/7c/Eiheiji.jpg" alt="永平寺" width="4316" height="3452" style="aspect-ratio: 4316 / 3452;">
 _圖片來源：Wikimedia Commons_
 
 永平寺位於福井縣大本山，由道元禪師於 1244 年創立，是日本曹洞宗的兩大本山之一。

--- a/docs/日本/福島/景點/大內宿.md
+++ b/docs/日本/福島/景點/大內宿.md
@@ -10,7 +10,7 @@
 - **[五箇山合掌集落](../../富山/景點/五箇山)：** 位於富山縣，氛圍較為淳樸。
 - **[大內宿](./大內宿)：** 以江戶時代宿場町風情與大蔥蕎麥麵聞名。
 
-![大內宿](https://upload.wikimedia.org/wikipedia/commons/e/e3/Ouchijuku_2006-11-12.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/e/e3/Ouchijuku_2006-11-12.jpg" alt="大內宿" width="2592" height="1944" style="aspect-ratio: 2592 / 1944;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/秋田/景點/乳頭溫泉鄉.md
+++ b/docs/日本/秋田/景點/乳頭溫泉鄉.md
@@ -2,7 +2,7 @@
 
 乳頭溫泉鄉位於日本秋田縣仙北市的田澤湖高原地區，由七家各具特色的溫泉旅館組成。這裡以多樣的泉質和豐富的自然景觀聞名，是放鬆身心的理想場所。
 
-![乳頭溫泉鄉](https://upload.wikimedia.org/wikipedia/commons/8/8b/Qkamura_Nyuto_Onsenkyo.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/8/8b/Qkamura_Nyuto_Onsenkyo.jpg" alt="乳頭溫泉鄉" width="3200" height="1800" style="aspect-ratio: 3200 / 1800;">
 _圖片來源：Wikimedia Commons_
 
 ## 交通方式

--- a/docs/日本/秋田/景點/千秋公園.md
+++ b/docs/日本/秋田/景點/千秋公園.md
@@ -2,7 +2,7 @@
 
 千秋公園位於秋田市中心，是江戶時代秋田藩主佐竹氏的居城「久保田城」的遺址。現在則是一座充滿歷史氣息的城市公園，也是秋田市著名的賞櫻與賞楓名所。
 
-![千秋公園](https://upload.wikimedia.org/wikipedia/commons/c/cb/Senshu_park_-_Akita_-_2024_March_28_various.jpeg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/c/cb/Senshu_park_-_Akita_-_2024_March_28_various.jpeg" alt="千秋公園" width="4032" height="3024" style="aspect-ratio: 4032 / 3024;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/秋田/景點/秋田市民俗藝能傳承館.md
+++ b/docs/日本/秋田/景點/秋田市民俗藝能傳承館.md
@@ -2,7 +2,7 @@
 
 秋田市民俗藝能傳承館（又稱「ねぶり流し館」）旨在保存與展示秋田市傳統的民俗藝能，特別是著名的「秋田竿燈祭」。
 
-![秋田竿燈祭](https://upload.wikimedia.org/wikipedia/commons/f/f5/Akita_Kanto_Festival_2017.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/f/f5/Akita_Kanto_Festival_2017.jpg" alt="秋田竿燈祭" width="4608" height="2592" style="aspect-ratio: 4608 / 2592;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/青森/十和田/景點/奧入瀨溪流.md
+++ b/docs/日本/青森/十和田/景點/奧入瀨溪流.md
@@ -1,6 +1,6 @@
 奧入瀨溪流位於青森縣十和田市，是十和田湖流出的唯一河川，全長約 14 公里。這裡被指定為日本的特別名勝及天然紀念物，以其清澈的溪流、茂密的森林和多處瀑布而聞名。
 
-![奧入瀨溪流](https://upload.wikimedia.org/wikipedia/commons/8/85/Oirase_Stream%2C_Towada-Hachimantai_National_Park%2C_Japan.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/8/85/Oirase_Stream%2C_Towada-Hachimantai_National_Park%2C_Japan.jpg" alt="奧入瀨溪流" width="4032" height="3024" style="aspect-ratio: 4032 / 3024;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/青森/弘前/景點/弘前城.md
+++ b/docs/日本/青森/弘前/景點/弘前城.md
@@ -2,7 +2,7 @@
 
 弘前城位於青森縣弘前市，是江戶時代弘前藩津輕氏的居城。它是日本東北地區唯一保留有江戶時代建造的天守閣的城堡，被指定為國家重要文化財。
 
-![弘前城](https://upload.wikimedia.org/wikipedia/commons/f/fa/Hirosaki_Castle.JPG)
+<img src="https://upload.wikimedia.org/wikipedia/commons/f/fa/Hirosaki_Castle.JPG" alt="弘前城" width="3888" height="2592" style="aspect-ratio: 3888 / 2592;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/青森/深浦/景點/不老不死溫泉.md
+++ b/docs/日本/青森/深浦/景點/不老不死溫泉.md
@@ -2,7 +2,7 @@
 
 不老不死溫泉位於青森縣西津輕郡深浦町，以其緊鄰日本海的露天風呂而聞名。溫泉水含有豐富的鐵質，呈現獨特的紅褐色。
 
-![不老不死溫泉](https://upload.wikimedia.org/wikipedia/commons/9/9b/Furofushi_Onsen.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/9/9b/Furofushi_Onsen.jpg" alt="不老不死溫泉" width="427" height="240" style="aspect-ratio: 427 / 240;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/青森/青森/景點/八甲田山.md
+++ b/docs/日本/青森/青森/景點/八甲田山.md
@@ -2,7 +2,7 @@
 
 八甲田山位於青森市南側，是日本百名山之一。它並非單一座山峰，而是由大岳、田茂萢岳等十多座火山組成的連峰。這裡以壯麗的自然景觀、冬季的「雪怪」樹冰以及優質的溫泉而聞名。
 
-![八甲田山](https://upload.wikimedia.org/wikipedia/commons/7/74/Hakk%C5%8Dda_Mountains_in_winter.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/7/74/Hakk%C5%8Dda_Mountains_in_winter.jpg" alt="八甲田山" width="1024" height="768" style="aspect-ratio: 1024 / 768;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/日本/青森/青森/景點/酸湯溫泉.md
+++ b/docs/日本/青森/青森/景點/酸湯溫泉.md
@@ -2,7 +2,7 @@
 
 酸湯溫泉位於八甲田山麓，海拔約 900 公尺，是一座擁有超過 300 年歷史的古老溫泉。它以其巨大的「千人風呂」和強酸性的泉質而聞名，是日本著名的國民保養溫泉地。
 
-![酸湯溫泉](https://upload.wikimedia.org/wikipedia/commons/4/40/Sukayu_Onsen_01.jpg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/4/40/Sukayu_Onsen_01.jpg" alt="酸湯溫泉" width="3813" height="1985" style="aspect-ratio: 3813 / 1985;">
 _圖片來源：Wikimedia Commons_
 
 ## 景點特色

--- a/docs/瑞士/index.md
+++ b/docs/瑞士/index.md
@@ -1,6 +1,6 @@
 # 瑞士 (Switzerland)
 
-![Switzerland photo by Huang An Sheng](https://i.imgur.com/HUm2oe3.jpg)
+<img src="https://i.imgur.com/HUm2oe3.jpg" alt="Switzerland photo by Huang An Sheng" width="1170" height="1012" style="aspect-ratio: 1170 / 1012;">
 
 瑞士聯邦為中歐國家，由 26 個州組成。瑞士是一個內陸國家，在地理上被劃分成阿爾卑斯山、瑞士高原及侏羅山脈三部份，其山地總面積達 41,285 平方公里，當中以阿爾卑斯山最為廣闊。瑞士高原不僅是瑞士 800 萬人口的集中區域，也是該國主要城市日內瓦及經濟中心蘇黎世的所在地。瑞士的自然風光及氣候條件十分優越，因而素有「世界公園」或「世界花園」之美譽。
 

--- a/docs/瑞士/伯恩州/Einstein Café & bel étage.md
+++ b/docs/瑞士/伯恩州/Einstein Café & bel étage.md
@@ -1,6 +1,6 @@
 # Einstein Café & bel étage
 
-![Einstein Café & bel étage photo by Huang An Sheng](https://i.imgur.com/ZIbnamN.jpg)
+<img src="https://i.imgur.com/ZIbnamN.jpg" alt="Einstein Café & bel étage photo by Huang An Sheng" width="1170" height="1026" style="aspect-ratio: 1170 / 1026;">
 
 著名物理學家愛因斯坦故居，現在已經被改建成一間咖啡店，位於伯恩老城區的市中心。
 

--- a/docs/瑞士/伯恩州/Zytglogge.md
+++ b/docs/瑞士/伯恩州/Zytglogge.md
@@ -1,6 +1,6 @@
 # Zytglogge
 
-![Zytglogge photo by Huang An Sheng](https://i.imgur.com/jHenIgJ.jpg)
+<img src="https://i.imgur.com/jHenIgJ.jpg" alt="Zytglogge photo by Huang An Sheng" width="1170" height="1223" style="aspect-ratio: 1170 / 1223;">
 
 位於伯恩市中心的鐘樓，是個相當顯著的地標，也是許多去伯恩旅行的旅行團會選擇的集結點。
 

--- a/docs/瑞士/伯恩州/伯恩古城區.md
+++ b/docs/瑞士/伯恩州/伯恩古城區.md
@@ -1,6 +1,6 @@
 # 伯恩古城區
 
-![Bern photo by Huang An Sheng](https://i.imgur.com/BFZXQ3A.jpg)
+<img src="https://i.imgur.com/BFZXQ3A.jpg" alt="Bern photo by Huang An Sheng" width="1170" height="942" style="aspect-ratio: 1170 / 942;">
 
 伯恩是瑞士聯邦政府所在地兼事實上的首都。瑞士伯恩的舊城區，建造於三面環河的小山上。目前仍保留大部分中世紀的面貌，並與現代城市的機能巧妙地融合。1983 年被列為世界文化遺產。當前老城內的眾多建築以及整個老城都被指定為瑞士國家級文化財產。
 

--- a/docs/瑞士/佛德州/Château de Chillon.md
+++ b/docs/瑞士/佛德州/Château de Chillon.md
@@ -1,6 +1,6 @@
 # Château de Chillon
 
-![Château de Chillon photo by Huang An Sheng](https://i.imgur.com/9fQOK1j.jpg)
+<img src="https://i.imgur.com/9fQOK1j.jpg" alt="Château de Chillon photo by Huang An Sheng" width="1420" height="1137" style="aspect-ratio: 1420 / 1137;">
 
 又名 Chillon Castle 是瑞士最著名的古堡之一，位於日內瓦湖畔，湖的對岸是瑞士法國邊界，距離蒙特勒約 3 公里，是瑞士最受歡迎的旅遊景點之一。
 

--- a/docs/瑞士/佛德州/日內瓦湖.md
+++ b/docs/瑞士/佛德州/日內瓦湖.md
@@ -1,6 +1,6 @@
 # 日內瓦湖 (lac de Genève)
 
-![lac de Genève photo by Huang An Sheng](https://i.imgur.com/BcDpzf1.jpg)
+<img src="https://i.imgur.com/BcDpzf1.jpg" alt="lac de Genève photo by Huang An Sheng" width="1170" height="1386" style="aspect-ratio: 1170 / 1386;">
 
 萊芒湖 (法語：lac Léman)，又稱日內瓦湖 (lac de Genève)。湖北岸和東西兩端分屬瑞士佛德州、瓦萊州和日內瓦州，南岸則屬於法國上薩瓦省。瑞士和法國分別占有湖面的 60% 和 40%。
 

--- a/docs/瑞士/提契諾州/盧加諾湖.md
+++ b/docs/瑞士/提契諾州/盧加諾湖.md
@@ -1,6 +1,6 @@
 # 盧加諾湖 (義大利語：Lago di Lugano)
 
-![Lago di Lugano photo by Huang An Sheng](https://i.imgur.com/UoUCTpN.jpg)
+<img src="https://i.imgur.com/UoUCTpN.jpg" alt="Lago di Lugano photo by Huang An Sheng" width="1361" height="845" style="aspect-ratio: 1361 / 845;">
 
 盧加諾湖 (義大利語：Lago di Lugano) 位於瑞士東南部，處瑞士和義大利兩國交界處的一個湖泊。湖名來源於瑞士城市盧加諾。位於馬焦雷湖和科莫湖之間。盧加諾湖是一個知名的觀光地。
 

--- a/docs/瑞士/瓦萊州/Gornergrat.md
+++ b/docs/瑞士/瓦萊州/Gornergrat.md
@@ -1,6 +1,6 @@
 # Gornergrat
 
-![Gornergrat photo by Huang An Sheng](https://i.imgur.com/pFHiWTQ.jpg)
+<img src="https://i.imgur.com/pFHiWTQ.jpg" alt="Gornergrat photo by Huang An Sheng" width="1420" height="1826" style="aspect-ratio: 1420 / 1826;">
 
 一個可以看到馬特洪峰的觀景台，可以搭登山火車上去。這裡除了可以觀賞馬特洪峰之外，也可以看到阿爾卑斯山脈的 Grenzgletscher 冰河。
 

--- a/docs/瑞士/瓦萊州/策馬特.md
+++ b/docs/瑞士/瓦萊州/策馬特.md
@@ -1,6 +1,6 @@
 # 策馬特 (Zermatt)
 
-![Zermatt photo by Huang An Sheng](https://i.imgur.com/WmZbTE3.jpg)
+<img src="https://i.imgur.com/WmZbTE3.jpg" alt="Zermatt photo by Huang An Sheng" width="1420" height="1826" style="aspect-ratio: 1420 / 1826;">
 
 策馬特 (Zermatt) 位於馬特洪峰 Matterhorn 脚下，其旅遊業發展與世界上最著名山峰之一的馬特洪峰息息相關。這個渡假勝地禁止車輛通行，致使它很好地保留清新的原貌，爲旅客的觀光提供了無限的可能性。
 

--- a/docs/瑞士/瓦萊州/馬特洪峰.md
+++ b/docs/瑞士/瓦萊州/馬特洪峰.md
@@ -1,6 +1,6 @@
 # 馬特洪峰 (Matterhorn)
 
-![Matterhorn photo by Huang An Sheng](https://i.imgur.com/7udczKL.jpg)
+<img src="https://i.imgur.com/7udczKL.jpg" alt="Matterhorn photo by Huang An Sheng" width="1420" height="1402" style="aspect-ratio: 1420 / 1402;">
 
 馬特洪峰，也稱切爾維諾峰，是阿爾卑斯山脈中最著名的山峰。馬特洪峰的位置在瑞士、義大利邊境，馬特洪峰的名稱是由德語「Matt」（意為草地）和「Horn」（意為角，或呈錐狀像一隻角一樣的山峰）組成。
 

--- a/docs/瑞士/聖加侖州/聖加侖修道院.md
+++ b/docs/瑞士/聖加侖州/聖加侖修道院.md
@@ -1,6 +1,6 @@
 # 聖加侖修道院 (Fürstabtei Sankt Gallen)
 
-![Fürstabtei Sankt Gallen photo by Huang An Sheng](https://i.imgur.com/5EX5045.jpg)
+<img src="https://i.imgur.com/5EX5045.jpg" alt="Fürstabtei Sankt Gallen photo by Huang An Sheng" width="1420" height="1776" style="aspect-ratio: 1420 / 1776;">
 
 是瑞士聖加侖的一組文藝復興風格的天主教建築群。聖加侖修道院，及其巴洛克風格的大教堂 Baroque cathedral 是這座城市的地標，修道院及其圖書館和修道院檔案館於 1983 年被聯合國教科文組織確定爲世界文化遺産。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "mermaid": "^11.12.2",
         "open-graph-scraper": "^6.10.0",
         "prettier": "^3.7.4",
+        "probe-image-size": "^7.2.3",
         "sass": "^1.97.2",
         "segment": "^0.1.3",
         "vitepress": "^v2.0.0-alpha.15",
@@ -4127,6 +4128,19 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/immutable": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
@@ -4361,6 +4375,13 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5191,6 +5212,34 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/needle": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/needle/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
@@ -5472,6 +5521,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/probe-image-size": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
+      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.merge": "^4.6.2",
+        "needle": "^2.5.2",
+        "stream-parser": "~0.3.1"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -5489,17 +5550,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/react": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/readdirp": {
@@ -5716,13 +5766,15 @@
         "@parcel/watcher": "^2.4.1"
       }
     },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
@@ -5797,6 +5849,33 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2"
+      }
+    },
+    "node_modules/stream-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/stream-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "vitepress build ./",
     "check": "npx prettier --check .",
     "format": "npx prettier --write .",
+    "gen:img": "npx tsx scripts/generate-image-dimensions.ts",
     "prepare": "husky install"
   },
   "repository": {
@@ -58,6 +59,7 @@
     "mermaid": "^11.12.2",
     "open-graph-scraper": "^6.10.0",
     "prettier": "^3.7.4",
+    "probe-image-size": "^7.2.3",
     "sass": "^1.97.2",
     "segment": "^0.1.3",
     "vitepress": "^v2.0.0-alpha.15",

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -6,6 +6,8 @@
 
 ## 既有腳本
 
+- `generate-image-dimensions.ts` 掃描 `docs/` 內的圖片，透過 Wikimedia API 或 `probe-image-size` 取得寬高，並快取至 `.vitepress/image-dimensions.json`。具備頻率限制（Rate Limit）處理機制。
+- `update-markdown-images.ts` 讀取尺寸快取，將 Markdown 圖片語法 `![alt](url)` 替換為包含尺寸的 `<img>` 標籤，以優化 CLS。
 - `verify-links.ts` 掃描 Markdown 的 `相關連結` 區塊，拒絕黑名單來源網域，並檢查 URL 是否可連線。
 - `verify-images.ts` 掃描 Markdown 圖片，檢查遠端圖片 URL，並可修復部分 Wikimedia 連結。
 - `get-wikimedia-image.ts` 將 Wikimedia Commons 檔案頁或檔名解析成直接圖片 URL。
@@ -18,6 +20,10 @@
 - 新 import 優先使用帶有 `node:` 前綴的 Node 內建模組。
 - 腳本應可從儲存庫根目錄用專案工具鏈執行，通常是 `npx tsx scripts/name.ts`；若腳本本來支援 Bun，註解也可提到 Bun。
 - URL 檢查腳本應明確設定網路逾時與 User-Agent 標頭。
+- **圖片正規表達式**：處理 Markdown 圖片時，必須使用可處理平衡括號的 Regex：`/!\[(.*?)\]\(((?:[^()]+|\([^()]*\))*)\)/g`。這是因為許多圖片網址（特別是 Wikimedia）本身包含括號（如 `...File_Name_(0155).jpg`），標準非貪婪比對會提前截斷網址。
+- **API 頻率限制與 Quirks**：
+  - 存取外部 API（如 Wikimedia）時，必須實作 sleep 或 batching 處理，避免觸發 429 Too Many Requests。
+  - Wikimedia API 的 `titles` 參數對大小寫、底線（`_`）與空格敏感。在比對 API 回傳結果與原始網址時，建議將兩者正規化（如移除空格與底線後轉小寫）再進行比對。
 - 檢查連結時，除非最終目的地錯誤或非官方，否則 HTTP 重新導向（`3xx`）視為有效。
 - 自動替換 URL 或內容時，將替換目標組成正規表達式前，必須先進行 escape。
 - 除非腳本清楚回報變更檔案，否則避免大範圍自動改寫內容。

--- a/scripts/generate-image-dimensions.ts
+++ b/scripts/generate-image-dimensions.ts
@@ -110,7 +110,7 @@ async function run() {
       dimensions[url] = { width: result.width, height: result.height }
       console.log(`  Success (Probe): ${result.width}x${result.height}`)
       fs.writeFileSync(outputJson, JSON.stringify(dimensions, null, 2))
-      await sleep(10000) // 10s wait after probe to avoid 429
+      await sleep(1000) // 1s wait after probe is usually sufficient
     } catch (e: any) {
       console.error(`  Failed: ${e.message}`)
       if (e.message.includes('429')) {

--- a/scripts/generate-image-dimensions.ts
+++ b/scripts/generate-image-dimensions.ts
@@ -57,7 +57,7 @@ async function run() {
 
   const files = getFiles(docsDir)
   const imageUrls = new Set<string>()
-  const imgRegex = /!\[(.*?)\]\(((?:[^()]+|\([^()]*\))*)\)/g
+  const imgRegex = /!\[(.*?)\]\(((?:\([^()]*\)|[^()\s])+)\)/g
 
   for (const file of files) {
     const content = fs.readFileSync(file, 'utf-8')

--- a/scripts/generate-image-dimensions.ts
+++ b/scripts/generate-image-dimensions.ts
@@ -37,6 +37,7 @@ async function getWikimediaImageInfo(fileName: string) {
         headers: { 'User-Agent': 'TravelGuideTW-Bot/1.0' },
       })
       const data = (await response.json()) as any
+      if (!data.query?.pages) return null
       const pages = data.query.pages
       const pageId = Object.keys(pages)[0]
       if (pageId !== '-1' && pages[pageId].imageinfo) {

--- a/scripts/generate-image-dimensions.ts
+++ b/scripts/generate-image-dimensions.ts
@@ -1,0 +1,125 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import probe from 'probe-image-size'
+
+const docsDir = path.join(process.cwd(), 'docs')
+const outputJson = path.join(process.cwd(), '.vitepress/image-dimensions.json')
+
+function getFiles(dir: string, fileList: string[] = []): string[] {
+  if (!fs.existsSync(dir)) return []
+  const files = fs.readdirSync(dir)
+  files.forEach((file) => {
+    const filePath = path.join(dir, file)
+    if (fs.statSync(filePath).isDirectory()) {
+      getFiles(filePath, fileList)
+    } else if (filePath.endsWith('.md')) {
+      fileList.push(filePath)
+    }
+  })
+  return fileList
+}
+
+async function getWikimediaImageInfo(fileName: string) {
+  const titles = [
+    fileName,
+    decodeURIComponent(fileName),
+    fileName.replace(/_/g, ' '),
+    decodeURIComponent(fileName).replace(/_/g, ' '),
+  ]
+  const uniqueTitles = Array.from(new Set(titles))
+
+  for (const title of uniqueTitles) {
+    const t = title.startsWith('File:') ? title : 'File:' + title
+    const url = `https://commons.wikimedia.org/w/api.php?action=query&titles=${encodeURIComponent(t)}&prop=imageinfo&iiprop=url|size&format=json&origin=*`
+
+    try {
+      const response = await fetch(url, {
+        headers: { 'User-Agent': 'TravelGuideTW-Bot/1.0' },
+      })
+      const data = (await response.json()) as any
+      const pages = data.query.pages
+      const pageId = Object.keys(pages)[0]
+      if (pageId !== '-1' && pages[pageId].imageinfo) {
+        return pages[pageId].imageinfo[0]
+      }
+    } catch (e) {}
+  }
+  return null
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function run() {
+  const dimensions: Record<string, { width: number; height: number }> = {}
+  if (fs.existsSync(outputJson)) {
+    Object.assign(dimensions, JSON.parse(fs.readFileSync(outputJson, 'utf-8')))
+  }
+
+  const files = getFiles(docsDir)
+  const imageUrls = new Set<string>()
+  const imgRegex = /!\[(.*?)\]\(((?:[^()]+|\([^()]*\))*)\)/g
+
+  for (const file of files) {
+    const content = fs.readFileSync(file, 'utf-8')
+    for (const match of content.matchAll(imgRegex)) {
+      imageUrls.add(match[2])
+    }
+  }
+
+  console.log(`Found ${imageUrls.size} unique markdown images.`)
+
+  let batchCount = 0
+  for (const url of imageUrls) {
+    if (dimensions[url]) continue
+
+    console.log(`Processing ${url}...`)
+
+    if (url.includes('wikimedia.org')) {
+      const fileNameMatch =
+        url.match(/\/commons\/[a-z0-9]+\/[a-z0-9]+\/([^/]+)/) ||
+        url.match(/File:(.+)$/)
+      if (fileNameMatch) {
+        const fileName = fileNameMatch[1]
+        const info = await getWikimediaImageInfo(fileName)
+        if (info) {
+          dimensions[url] = { width: info.width, height: info.height }
+          console.log(`  Success (API): ${info.width}x${info.height}`)
+          fs.writeFileSync(outputJson, JSON.stringify(dimensions, null, 2))
+          await sleep(500)
+          continue
+        }
+      }
+    }
+
+    try {
+      const result = await probe(url, {
+        headers: {
+          'User-Agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        },
+        timeout: 10000,
+      })
+      dimensions[url] = { width: result.width, height: result.height }
+      console.log(`  Success (Probe): ${result.width}x${result.height}`)
+      fs.writeFileSync(outputJson, JSON.stringify(dimensions, null, 2))
+      await sleep(10000) // 10s wait after probe to avoid 429
+    } catch (e: any) {
+      console.error(`  Failed: ${e.message}`)
+      if (e.message.includes('429')) {
+        console.log('  Rate limited. Sleeping 30s...')
+        await sleep(30000)
+      }
+    }
+
+    batchCount++
+    if (batchCount >= 10) {
+      console.log('Stopping turn to avoid timeout. Run again to continue.')
+      break
+    }
+  }
+
+  fs.writeFileSync(outputJson, JSON.stringify(dimensions, null, 2))
+  console.log(`Saved. Total: ${Object.keys(dimensions).length}`)
+}
+
+run()

--- a/scripts/generate-image-dimensions.ts
+++ b/scripts/generate-image-dimensions.ts
@@ -120,8 +120,8 @@ async function run() {
     }
 
     batchCount++
-    if (batchCount >= 10) {
-      console.log('Stopping turn to avoid timeout. Run again to continue.')
+    if (batchCount >= 50) {
+      console.log('Stopping batch to avoid potential timeout. Run again to continue.')
       break
     }
   }

--- a/scripts/generate-image-dimensions.ts
+++ b/scripts/generate-image-dimensions.ts
@@ -74,7 +74,14 @@ async function run() {
 
     console.log(`Processing ${url}...`)
 
-    if (url.includes('wikimedia.org')) {
+    let isWikimediaUrl = false
+    try {
+      const parsedUrl = new URL(url)
+      const host = parsedUrl.hostname.toLowerCase()
+      isWikimediaUrl = host === 'wikimedia.org' || host.endsWith('.wikimedia.org')
+    } catch {}
+
+    if (isWikimediaUrl) {
       const fileNameMatch =
         url.match(/\/commons\/[a-z0-9]+\/[a-z0-9]+\/([^/]+)/) ||
         url.match(/File:(.+)$/)

--- a/scripts/update-markdown-images.ts
+++ b/scripts/update-markdown-images.ts
@@ -32,24 +32,59 @@ async function run() {
 
   for (const file of files) {
     let content = fs.readFileSync(file, 'utf-8')
-    // Regex explanation:
-    // !\[(.*?)\] - matches the alt text
-    // \( - matches the opening parenthesis of the URL
-    // ( - start of URL capture group
-    //   (?:[^()]+|\([^()]*\))* - matches non-parentheses OR one level of balanced parentheses
-    // ) - end of URL capture group
-    // \) - matches the closing parenthesis of the URL
-    const imgRegex = /!\[(.*?)\]\(((?:[^()]+|\([^()]*\))*)\)/g
     let modified = false
 
-    content = content.replace(imgRegex, (match, alt, url) => {
+    let result = ''
+    let i = 0
+
+    while (i < content.length) {
+      const start = content.indexOf('![', i)
+      if (start === -1) {
+        result += content.slice(i)
+        break
+      }
+
+      result += content.slice(i, start)
+
+      const altEnd = content.indexOf(']', start + 2)
+      if (altEnd === -1 || altEnd + 1 >= content.length || content[altEnd + 1] !== '(') {
+        result += content.slice(start, start + 2)
+        i = start + 2
+        continue
+      }
+
+      const alt = content.slice(start + 2, altEnd)
+      let j = altEnd + 2
+      let depth = 1
+
+      while (j < content.length && depth > 0) {
+        const ch = content[j]
+        if (ch === '(') depth++
+        else if (ch === ')') depth--
+        j++
+      }
+
+      if (depth !== 0) {
+        result += content.slice(start, start + 2)
+        i = start + 2
+        continue
+      }
+
+      const url = content.slice(altEnd + 2, j - 1)
+      const fullMatch = content.slice(start, j)
       const dim = dimensions[url]
+
       if (dim) {
         modified = true
-        return `<img src="${url}" alt="${alt}" width="${dim.width}" height="${dim.height}" style="aspect-ratio: ${dim.width} / ${dim.height};">`
+        result += `<img src="${url}" alt="${alt}" width="${dim.width}" height="${dim.height}" style="aspect-ratio: ${dim.width} / ${dim.height};">`
+      } else {
+        result += fullMatch
       }
-      return match
-    })
+
+      i = j
+    }
+
+    content = result
 
     if (modified) {
       fs.writeFileSync(file, content)

--- a/scripts/update-markdown-images.ts
+++ b/scripts/update-markdown-images.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const docsDir = path.join(process.cwd(), 'docs')
+const dimensionsJson = path.join(
+  process.cwd(),
+  '.vitepress/image-dimensions.json',
+)
+
+function getFiles(dir: string, fileList: string[] = []): string[] {
+  if (!fs.existsSync(dir)) return []
+  const files = fs.readdirSync(dir)
+  files.forEach((file) => {
+    const filePath = path.join(dir, file)
+    if (fs.statSync(filePath).isDirectory()) {
+      getFiles(filePath, fileList)
+    } else if (filePath.endsWith('.md')) {
+      fileList.push(filePath)
+    }
+  })
+  return fileList
+}
+
+async function run() {
+  if (!fs.existsSync(dimensionsJson)) {
+    console.error('Dimensions JSON not found. Please run gen:img first.')
+    return
+  }
+
+  const dimensions = JSON.parse(fs.readFileSync(dimensionsJson, 'utf-8'))
+  const files = getFiles(docsDir)
+
+  for (const file of files) {
+    let content = fs.readFileSync(file, 'utf-8')
+    // Regex explanation:
+    // !\[(.*?)\] - matches the alt text
+    // \( - matches the opening parenthesis of the URL
+    // ( - start of URL capture group
+    //   (?:[^()]+|\([^()]*\))* - matches non-parentheses OR one level of balanced parentheses
+    // ) - end of URL capture group
+    // \) - matches the closing parenthesis of the URL
+    const imgRegex = /!\[(.*?)\]\(((?:[^()]+|\([^()]*\))*)\)/g
+    let modified = false
+
+    content = content.replace(imgRegex, (match, alt, url) => {
+      const dim = dimensions[url]
+      if (dim) {
+        modified = true
+        return `<img src="${url}" alt="${alt}" width="${dim.width}" height="${dim.height}" style="aspect-ratio: ${dim.width} / ${dim.height};">`
+      }
+      return match
+    })
+
+    if (modified) {
+      fs.writeFileSync(file, content)
+      console.log(`Updated ${path.relative(process.cwd(), file)}`)
+    }
+  }
+}
+
+run()


### PR DESCRIPTION
# 說明

新增腳本自動抓取 Markdown 圖片的尺寸，並將圖片語法轉換為 HTML `<img>` 標籤，以解決網頁載入時的 Cumulative Layout Shift (CLS) 問題。

## 改動內容

- 新增 `scripts/generate-image-dimensions.ts`，能從 Wikimedia API 以及透過探針獲取圖片寬高，並快取在 `.vitepress/image-dimensions.json` 中。
- 新增 `scripts/update-markdown-images.ts`，依據快取的尺寸，批次將 Markdown 中的圖片替換為具備 `width`, `height`, 及 `aspect-ratio` 屬性的 HTML `<img>` 標籤。
- 更新 `scripts/AGENTS.md` 加入圖片處理與 Wikimedia 爬取的相關指引。
- 批次套用修改，為 `docs/` 底下的數十個 Markdown 檔案的圖片注入尺寸標籤。
- 更新 `package.json` 加入 `probe-image-size` 依賴及 `gen:img` 指令。

## 相關資料

- 無